### PR TITLE
14 - Invalidate change event crashes the connector

### DIFF
--- a/test/acceptance/invalidate.go
+++ b/test/acceptance/invalidate.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package acceptance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/damianiandrea/mongodb-nats-connector/test/harness"
+)
+
+func TestMongoDropCollectionDoesNotCrashConnector(t *testing.T) {
+	ctx := context.Background()
+	h := harness.New(t, harness.FromEnv())
+
+	h.MustStartContainer(ctx, harness.Connector)
+	t.Cleanup(func() {
+		h.MustStopContainer(ctx, harness.Connector)
+		assert.NoError(t, h.MongoClient.Database("test-connector").Drop(ctx))
+		assert.NoError(t, h.MongoClient.Database("resume-tokens").Drop(ctx))
+		assert.NoError(t, h.NatsJs.PurgeStream("COLL1"))
+		assert.NoError(t, h.NatsJs.PurgeStream("COLL2"))
+	})
+
+	h.MustWaitForConnector(10 * time.Second)
+
+	h.MustMongoDropCollection(ctx, "test-connector", "coll1")
+
+	h.MustEnsureConnectorIsUpFor(1 * time.Second)
+}
+
+func TestMongoDropDatabaseDoesNotCrashConnector(t *testing.T) {
+	ctx := context.Background()
+	h := harness.New(t, harness.FromEnv())
+
+	h.MustStartContainer(ctx, harness.Connector)
+	t.Cleanup(func() {
+		h.MustStopContainer(ctx, harness.Connector)
+		assert.NoError(t, h.MongoClient.Database("test-connector").Drop(ctx))
+		assert.NoError(t, h.MongoClient.Database("resume-tokens").Drop(ctx))
+		assert.NoError(t, h.NatsJs.PurgeStream("COLL1"))
+		assert.NoError(t, h.NatsJs.PurgeStream("COLL2"))
+	})
+
+	h.MustWaitForConnector(10 * time.Second)
+
+	h.MustMongoDropDatabase(ctx, "test-connector")
+
+	h.MustEnsureConnectorIsUpFor(1 * time.Second)
+}
+
+func TestMongoRenameCollectionDoesNotCrashConnector(t *testing.T) {
+	ctx := context.Background()
+	h := harness.New(t, harness.FromEnv())
+
+	h.MustStartContainer(ctx, harness.Connector)
+	t.Cleanup(func() {
+		h.MustStopContainer(ctx, harness.Connector)
+		assert.NoError(t, h.MongoClient.Database("test-connector").Drop(ctx))
+		assert.NoError(t, h.MongoClient.Database("resume-tokens").Drop(ctx))
+		assert.NoError(t, h.NatsJs.PurgeStream("COLL1"))
+		assert.NoError(t, h.NatsJs.PurgeStream("COLL2"))
+	})
+
+	h.MustWaitForConnector(10 * time.Second)
+
+	h.MustMongoRenameCollection(ctx, "test-connector", "coll1", "coll3")
+
+	h.MustEnsureConnectorIsUpFor(1 * time.Second)
+}


### PR DESCRIPTION
When a watched collection is dropped or renamed, MongoDB sends an `invalidate` change event.

Such change event causes the connector to close the change stream and try to resume from the latest resume token, only for it to error out and crash.

In order to fix this problem this PR prevents the connector from resuming a change stream after it has received an `invalidate` event.