### PR TITLE
Connector fails to start when using changeStreamPreAndPostImages with MongoDB versions less than 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,26 +24,29 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: false
-    - name: Lint
-      uses: golangci/golangci-lint-action@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
 
   build:
+    strategy:
+      matrix:
+        mongo-version: [5.0-focal, 6.0-focal]
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-    - name: Unit Test
-      run: make test
-    - name: Integration Test
-      run: make it
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Unit Test
+        run: make test
+      - name: Integration Test
+        run: make it MONGO_VERSION=${{ matrix.mongo-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 .idea
 dist/
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
+MONGO_VERSION ?= 6.0-focal
+
 .PHONY: test
 
 test:
 	go test -v -race -cover ./...
 
-run:
-	docker-compose up --build -d mongo1 mongo2 mongo3 nats1 nats2 nats3 connector
+create-env:
+	echo MONGO_VERSION=$(MONGO_VERSION) > .env
 
-run-mongo-nats:
+run-mongo-nats: create-env
 	docker-compose up --build -d mongo1 mongo2 mongo3 nats1 nats2 nats3
+
+run: run-mongo-nats
+	docker-compose up --build connector
 
 create-connector:
 	docker-compose up --build --no-start connector

--- a/README.md
+++ b/README.md
@@ -64,13 +64,7 @@ Add a new record to our example collection `coll1`:
 db.coll1.insertOne({"message": "hi"})
 ```
 
-Now look at the connector's logs:
-
-```
-docker-compose logs -f connector
-```
-
-You should see something like the following:
+Now if you look at the connector's logs, you should see something like the following:
 
 ```
 connector  | {"time":"2023-05-09T12:59:38.0312255Z","level":"DEBUG","msg":"received change event","changeEvent":"{\"_id\":{\"_data\":\"82645A43BA000000012B022C0100296E5A100441C14B6
@@ -147,7 +141,8 @@ For each collection, the following properties can be configured:
 
 * `dbName`, the name of the database where the collection to watch resides.
 * `collName`, the name of the collection to watch.
-* `changeStreamPreAndPostImages`, this is a MongoDB configuration, more info
+* `changeStreamPreAndPostImages`, (Deprecated: will be removed in future versions. Set this configuration directly on MongoDB 
+instead.) - this is a MongoDB configuration, more info
 [here](https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images).
 * `tokensDbName`, the name of the database where the resume tokens collection will reside.
 * `tokensCollName`, the name of the resume tokens collection for the watched collection.

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -29,6 +29,7 @@ func main() {
 			connector.WithTokensCollName(coll.TokensCollName),
 			connector.WithStreamName(coll.StreamName),
 		}
+		// nolint:staticcheck
 		if coll.ChangeStreamPreAndPostImages != nil && *coll.ChangeStreamPreAndPostImages {
 			collOpts = append(collOpts, connector.WithChangeStreamPreAndPostImages())
 		}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     depends_on:
       - mongo2
       - mongo3
-    image: mongo:6.0-focal
+    image: mongo:${MONGO_VERSION}
     container_name: mongo1
     hostname: mongo1
     networks:
@@ -21,7 +21,7 @@ services:
       interval: 10s
       start_period: 30s
   mongo2:
-    image: mongo:6.0-focal
+    image: mongo:${MONGO_VERSION}
     container_name: mongo2
     hostname: mongo2
     networks:
@@ -33,7 +33,7 @@ services:
       restart_policy:
         condition: on-failure
   mongo3:
-    image: mongo:6.0-focal
+    image: mongo:${MONGO_VERSION}
     container_name: mongo3
     hostname: mongo3
     networks:
@@ -110,6 +110,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
     environment:
       - MONGO_URI=mongodb://mongo1:27017,mongo2:27017,mongo3:27017/?replicaSet=mongodb-nats-connector
+      - MONGO_VERSION=${MONGO_VERSION}
       - NATS_URL=nats://nats1:4222
       - CONNECTOR_URL=http://connector:8080
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,7 @@ type Server struct {
 type Collection struct {
 	DbName                       string `yaml:"dbName,omitempty"`
 	CollName                     string `yaml:"collName,omitempty"`
+	// Deprecated: will be removed in future versions. Set this configuration directly on MongoDB instead. 
 	ChangeStreamPreAndPostImages *bool  `yaml:"changeStreamPreAndPostImages,omitempty"`
 	TokensDbName                 string `yaml:"tokensDbName,omitempty"`
 	TokensCollName               string `yaml:"tokensCollName,omitempty"`

--- a/internal/mongo/client.go
+++ b/internal/mongo/client.go
@@ -29,7 +29,7 @@ const (
 )
 
 var publishableOperationTypes = map[string]struct{}{
-	insertOperationType: {}, 
+	insertOperationType: {},
 	updateOperationType: {},
 	replacOperationType: {},
 	deleteOperationType: {},
@@ -137,11 +137,11 @@ func (c *DefaultClient) CreateCollection(ctx context.Context, opts *CreateCollec
 
 	// enables change stream pre and post images
 	if opts.ChangeStreamPreAndPostImages {
-		err = db.RunCommand(ctx, bson.D{{Key: "collMod", Value: opts.CollName},
-			{Key: "changeStreamPreAndPostImages", Value: bson.D{{Key: "enabled", Value: true}}}}).Err()
-		if err != nil {
-			return fmt.Errorf("could not enable changeStreamPreAndPostImages on mongo collection %v: %v",
-				opts.CollName, err)
+		enablePreAndPostImages := bson.D{{Key: "collMod", Value: opts.CollName},
+			{Key: "changeStreamPreAndPostImages", Value: bson.D{{Key: "enabled", Value: true}}}}
+		if err = db.RunCommand(ctx, enablePreAndPostImages).Err(); err != nil {
+			c.logger.Warn("could not enable changeStreamPreAndPostImages, is your MongoDB version at least 6.0?", 
+			"collName", opts.CollName, "err", err)
 		}
 	}
 	return nil

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -350,6 +350,8 @@ type collection struct {
 type CollectionOption func(*collection) error
 
 // WithChangeStreamPreAndPostImages enables MongoDB's changeStreamPreAndPostImages configuration.
+//
+// Deprecated: will be removed in future versions. Set this configuration directly on MongoDB instead.
 func WithChangeStreamPreAndPostImages() CollectionOption {
 	return func(c *collection) error {
 		c.changeStreamPreAndPostImages = true

--- a/test/acceptance/delete_test.go
+++ b/test/acceptance/delete_test.go
@@ -48,7 +48,11 @@ func TestMongoDeleteIsPublishedToNats(t *testing.T) {
 		require.Equal(t, event.Id.Data, msg.Header.Get(nats.MsgIdHdr))
 		require.Equal(t, event.OperationType, "delete")
 		require.Nil(t, event.FullDocument)
-		require.Equal(t, event.FullDocumentBeforeChange.Message, "hi")
+		if harness.MustGetMongoMajorVersion(t) < 6 {
+			require.Nil(t, event.FullDocumentBeforeChange)
+		} else {
+			require.Equal(t, event.FullDocumentBeforeChange.Message, "hi")
+		}
 
 		lastResumeToken := &harness.ResumeToken{}
 		h.MustMongoFindOne(ctx, "resume-tokens", testColl, bson.D{}, bson.D{{Key: "$natural", Value: -1}}, lastResumeToken)

--- a/test/acceptance/replace_test.go
+++ b/test/acceptance/replace_test.go
@@ -49,7 +49,11 @@ func TestMongoReplaceIsPublishedToNats(t *testing.T) {
 		require.Equal(t, event.Id.Data, msg.Header.Get(nats.MsgIdHdr))
 		require.Equal(t, event.OperationType, "replace")
 		require.Equal(t, event.FullDocument.Message, "replaced")
-		require.Equal(t, event.FullDocumentBeforeChange.Message, "hi")
+		if harness.MustGetMongoMajorVersion(t) < 6 {
+			require.Nil(t, event.FullDocumentBeforeChange)
+		} else {
+			require.Equal(t, event.FullDocumentBeforeChange.Message, "hi")
+		}
 
 		lastResumeToken := &harness.ResumeToken{}
 		h.MustMongoFindOne(ctx, "resume-tokens", testColl, bson.D{}, bson.D{{Key: "$natural", Value: -1}}, lastResumeToken)

--- a/test/acceptance/update_test.go
+++ b/test/acceptance/update_test.go
@@ -49,7 +49,11 @@ func TestMongoUpdateIsPublishedToNats(t *testing.T) {
 		require.Equal(t, event.Id.Data, msg.Header.Get(nats.MsgIdHdr))
 		require.Equal(t, event.OperationType, "update")
 		require.Equal(t, event.FullDocument.Message, "bye")
-		require.Equal(t, event.FullDocumentBeforeChange.Message, "hi")
+		if harness.MustGetMongoMajorVersion(t) < 6 {
+			require.Nil(t, event.FullDocumentBeforeChange)
+		} else {
+			require.Equal(t, event.FullDocumentBeforeChange.Message, "hi")
+		}
 
 		lastResumeToken := &harness.ResumeToken{}
 		h.MustMongoFindOne(ctx, "resume-tokens", testColl, bson.D{}, bson.D{{Key: "$natural", Value: -1}}, lastResumeToken)

--- a/test/harness/harness.go
+++ b/test/harness/harness.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -290,6 +291,14 @@ func (h *Harness) MustVerifyMessageCorrectness(maxMsgs int, dbName, collName str
 		require.Equal(h.t, id, event.FullDocument.Id.Hex())
 		i++
 	}
+}
+
+func MustGetMongoMajorVersion(t *testing.T) int {
+	mongoVersion := os.Getenv("MONGO_VERSION")
+
+	major, err := strconv.Atoi(string(mongoVersion[0]))
+	require.NoError(t, err)
+	return major
 }
 
 type ChangeEvent struct {


### PR DESCRIPTION
Configuring the `changeStreamPreAndPostImages` in the `connector.yaml` file while using MongoDB versions prior to `6.0` causes the connector to fail at startup.

The goal of this PR is to write a WARN level log message that can better inform the user, and to prevent the connector from failing.

It also marks the `changeStreamPreAndPostImages` connector configuration as deprecated. The purpose of the connector was never to provide a way to configure MongoDB, and enabling such configuration should be done directly on the database.