### PR TITLE
Add observability for MongoDB operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,13 @@ create-env:
 run-mongo-nats: create-env
 	docker-compose up --build -d mongo1 mongo2 mongo3 nats1 nats2 nats3
 
+run-prometheus-grafana:
+	docker-compose up --build -d prometheus grafana
+
 run: run-mongo-nats
 	docker-compose up --build connector
+
+run-observed: run-prometheus-grafana run
 
 create-connector:
 	docker-compose up --build --no-start connector

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,6 +74,28 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
+  prometheus:
+    image: prom/prometheus:v2.51.1
+    container_name: prometheus
+    networks:
+      - connector-net
+    ports:
+      - "9090:9090"
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+    deploy:
+      restart_policy:
+        condition: on-failure
+  grafana:
+    image: grafana/grafana:10.2.6
+    container_name: grafana
+    networks:
+      - connector-net
+    ports:
+      - "3000:3000"
+    deploy:
+      restart_policy:
+        condition: on-failure
   connector:
     depends_on:
       - mongo1

--- a/internal/prometheus/handler.go
+++ b/internal/prometheus/handler.go
@@ -1,5 +1,0 @@
-package prometheus
-
-import "github.com/prometheus/client_golang/prometheus/promhttp"
-
-var Handler = promhttp.Handler()

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -1,0 +1,72 @@
+package prometheus
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	commandsStarted = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mongodb_commands_started_total",
+			Help: "Total number of started commands.",
+		},
+		[]string{"database", "command"},
+	)
+
+	commandsSucceeded = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mongodb_commands_succeded_total",
+			Help: "Total number of succeeded commands.",
+		},
+		[]string{"database", "command"},
+	)
+
+	commandsFailed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mongodb_commands_failed_total",
+			Help: "Total number of failed commands.",
+		},
+		[]string{"database", "command", "failure_message"},
+	)
+
+	commandSucceededDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "mongodb_succeeded_command_duration_seconds",
+			Help:    "Duration of succeeded commands in seconds.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"database", "command"},
+	)
+
+	commandFailedDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "mongodb_failed_command_duration_seconds",
+			Help:    "Duration of failed commands in seconds.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"database", "command", "failure_message"},
+	)
+)
+
+func IncCmdStarted(dbName, cmdName string) {
+	commandsStarted.WithLabelValues(dbName, cmdName).Inc()
+}
+
+func ObserveCmdSucceeded(dbName, cmdName string, duration time.Duration) {
+	commandsSucceeded.WithLabelValues(dbName, cmdName).Inc()
+	commandSucceededDuration.WithLabelValues(dbName, cmdName).Observe(duration.Seconds())
+}
+
+func ObserveCmdFailed(dbName, cmdName, failure string, duration time.Duration) {
+	commandsFailed.WithLabelValues(dbName, cmdName).Inc()
+	commandFailedDuration.WithLabelValues(dbName, cmdName, failure).Observe(duration.Seconds())
+}
+
+func HTTPHandler() http.Handler {
+	return promhttp.Handler()
+}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -66,6 +66,11 @@ func New(opts ...Option) (*Connector, error) {
 		mongoClient, err := mongo.NewDefaultClient(
 			mongo.WithMongoUri(c.options.mongoUri),
 			mongo.WithLogger(c.logger),
+			mongo.WithEventListeners(
+				mongo.OnCmdStartedEvent(prometheus.IncCmdStarted),
+				mongo.OnCmdSucceededEvent(prometheus.ObserveCmdSucceeded),
+				mongo.OnCmdFailedEvent(prometheus.ObserveCmdFailed),
+			),
 		)
 		if err != nil {
 			return nil, err
@@ -91,7 +96,7 @@ func New(opts ...Option) (*Connector, error) {
 		server.WithContext(c.options.ctx),
 		server.WithNamedMonitors(c.options.mongoClient, c.options.natsClient),
 		server.WithLogger(c.logger),
-		server.WithMetricsHandler(prometheus.Handler),
+		server.WithMetricsHandler(prometheus.HTTPHandler()),
 	)
 
 	return c, nil

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: 'mongodb-nats-connector'
+    scrape_interval: 1s
+    static_configs:
+      - targets: ['connector:8080']


### PR DESCRIPTION
This PR adds the following custom metrics:

* `mongodb_commands_started_total` (Total number of started commands)
* `mongodb_commands_succeded_total` (Total number of succeeded commands)
* `mongodb_commands_failed_total` (Total number of failed commands)
* `mongodb_succeeded_command_duration_seconds` (Duration of succeeded commands in seconds)
* `mongodb_failed_command_duration_seconds` (Duration of failed commands in seconds)

It also adds Prometheus and Grafana to the `docker-compose.yaml`.