### PR TITLE
Add observability for NATS operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.10.14
 	github.com/nats-io/nats.go v1.34.1
 	github.com/prometheus/client_golang v1.19.1
+	github.com/prometheus/client_model v0.5.0
 	github.com/stretchr/testify v1.9.0
 	go.mongodb.org/mongo-driver v1.15.0
 	golang.org/x/sync v0.7.0
@@ -40,7 +41,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/internal/mongo/client.go
+++ b/internal/mongo/client.go
@@ -74,7 +74,7 @@ type DefaultClient struct {
 
 	onCmdStartedEvent   func(dbName, cmdName string)
 	onCmdSucceededEvent func(dbName, cmdName string, duration time.Duration)
-	onCmdFailedEvent    func(dbName, cmdName, failure string, duration time.Duration)
+	onCmdFailedEvent    func(dbName, cmdName string, duration time.Duration)
 
 	client *mongo.Client
 }
@@ -107,7 +107,7 @@ func NewDefaultClient(opts ...ClientOption) (*DefaultClient, error) {
 		},
 		Failed: func(ctx context.Context, e *event.CommandFailedEvent) {
 			if c.onCmdFailedEvent != nil {
-				c.onCmdFailedEvent(e.DatabaseName, e.CommandName, e.Failure, e.Duration)
+				c.onCmdFailedEvent(e.DatabaseName, e.CommandName, e.Duration)
 			}
 		},
 	}
@@ -306,7 +306,7 @@ func OnCmdSucceededEvent(onCmdSucceededEvent func(dbName, cmdName string, durati
 	}
 }
 
-func OnCmdFailedEvent(onCmdFailedEvent func(dbName, cmdName, failure string, duration time.Duration)) EventListener {
+func OnCmdFailedEvent(onCmdFailedEvent func(dbName, cmdName string, duration time.Duration)) EventListener {
 	return func(c *DefaultClient) {
 		if onCmdFailedEvent != nil {
 			c.onCmdFailedEvent = onCmdFailedEvent

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -123,7 +123,7 @@ func (c *DefaultClient) Publish(ctx context.Context, opts *PublishOptions) error
 		nats.Context(ctx),
 		nats.MsgId(opts.MsgId),
 	)
-	
+
 	duration := time.Since(start)
 	if err != nil {
 		if c.onMsgFailedEvent != nil {

--- a/internal/prometheus/prometheus_test.go
+++ b/internal/prometheus/prometheus_test.go
@@ -1,0 +1,165 @@
+package prometheus
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMongoRegisterer_IncMongoCmdStarted(t *testing.T) {
+	var (
+		registerer     = prometheus.NewPedanticRegistry()
+		expectedDbName = "test-db"
+		expectedCmd    = "insert"
+	)
+
+	mr := NewMongoRegisterer(registerer)
+	mr.IncMongoCmdStarted(expectedDbName, expectedCmd)
+
+	startedTotal := getMetric(t, registerer, "mongodb_commands_started_total")
+	require.NotNil(t, startedTotal)
+	require.Equal(t, 1.0, startedTotal.Counter.GetValue())
+	requireMetricHasLabel(t, startedTotal, "database", expectedDbName)
+	requireMetricHasLabel(t, startedTotal, "command", expectedCmd)
+}
+
+func TestMongoRegisterer_ObserveMongoCmdSucceeded(t *testing.T) {
+	var (
+		registerer       = prometheus.NewPedanticRegistry()
+		expectedDbName   = "test-db"
+		expectedCmd      = "insert"
+		expectedDuration = 1 * time.Second
+	)
+
+	mr := NewMongoRegisterer(registerer)
+	mr.ObserveMongoCmdSucceeded(expectedDbName, expectedCmd, expectedDuration)
+
+	succeededTotal := getMetric(t, registerer, "mongodb_commands_succeded_total")
+	require.NotNil(t, succeededTotal)
+	require.Equal(t, 1.0, succeededTotal.Counter.GetValue())
+	requireMetricHasLabel(t, succeededTotal, "database", expectedDbName)
+	requireMetricHasLabel(t, succeededTotal, "command", expectedCmd)
+
+	duration := getMetric(t, registerer, "mongodb_command_duration_seconds")
+	require.NotNil(t, duration)
+	require.Equal(t, expectedDuration.Seconds(), duration.Histogram.GetSampleSum())
+	requireMetricHasLabel(t, duration, "database", expectedDbName)
+	requireMetricHasLabel(t, duration, "command", expectedCmd)
+}
+
+func TestMongoRegisterer_ObserveMongoCmdFailed(t *testing.T) {
+	var (
+		registerer       = prometheus.NewPedanticRegistry()
+		expectedDbName   = "test-db"
+		expectedCmd      = "insert"
+		expectedDuration = 1 * time.Second
+	)
+
+	mr := NewMongoRegisterer(registerer)
+	mr.ObserveMongoCmdFailed(expectedDbName, expectedCmd, expectedDuration)
+
+	failedTotal := getMetric(t, registerer, "mongodb_commands_failed_total")
+	require.NotNil(t, failedTotal)
+	require.Equal(t, 1.0, failedTotal.Counter.GetValue())
+	requireMetricHasLabel(t, failedTotal, "database", expectedDbName)
+	requireMetricHasLabel(t, failedTotal, "command", expectedCmd)
+
+	duration := getMetric(t, registerer, "mongodb_command_duration_seconds")
+	require.NotNil(t, duration)
+	require.Equal(t, expectedDuration.Seconds(), duration.Histogram.GetSampleSum())
+	requireMetricHasLabel(t, duration, "database", expectedDbName)
+	requireMetricHasLabel(t, duration, "command", expectedCmd)
+}
+
+func TestNatsRegisterer_ObserveNatsMsgPublished(t *testing.T) {
+	var (
+		registerer       = prometheus.NewPedanticRegistry()
+		expectedSubject  = "coll1.insert"
+		expectedDuration = 1 * time.Second
+	)
+
+	nr := NewNatsRegisterer(registerer)
+	nr.ObserveNatsMsgPublished(expectedSubject, expectedDuration)
+
+	publishedTotal := getMetric(t, registerer, "nats_messages_published_total")
+	require.NotNil(t, publishedTotal)
+	require.Equal(t, 1.0, publishedTotal.Counter.GetValue())
+	requireMetricHasLabel(t, publishedTotal, "subject", expectedSubject)
+
+	duration := getMetric(t, registerer, "nats_message_duration_seconds")
+	require.NotNil(t, duration)
+	require.Equal(t, expectedDuration.Seconds(), duration.Histogram.GetSampleSum())
+	requireMetricHasLabel(t, duration, "subject", expectedSubject)
+}
+
+func TestNatsRegisterer_ObserveNatsMsgFailed(t *testing.T) {
+	var (
+		registerer       = prometheus.NewPedanticRegistry()
+		expectedSubject  = "coll1.insert"
+		expectedDuration = 1 * time.Second
+	)
+
+	nr := NewNatsRegisterer(registerer)
+	nr.ObserveNatsMsgFailed(expectedSubject, expectedDuration)
+
+	failedTotal := getMetric(t, registerer, "nats_messages_failed_total")
+	require.NotNil(t, failedTotal)
+	require.Equal(t, 1.0, failedTotal.Counter.GetValue())
+	requireMetricHasLabel(t, failedTotal, "subject", expectedSubject)
+
+	duration := getMetric(t, registerer, "nats_message_duration_seconds")
+	require.NotNil(t, duration)
+	require.Equal(t, expectedDuration.Seconds(), duration.Histogram.GetSampleSum())
+	requireMetricHasLabel(t, duration, "subject", expectedSubject)
+}
+
+func TestDefaultRegisterer(t *testing.T) {
+	registerer := DefaultRegisterer()
+
+	require.Equal(t, prometheus.DefaultRegisterer, registerer)
+}
+
+func TestHTTPHandler(t *testing.T) {
+	var (
+		rec = httptest.NewRecorder()
+		req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	)
+
+	HTTPHandler().ServeHTTP(rec, req)
+	
+	require.Equal(t, http.StatusOK, rec.Code)
+	res, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+}
+
+func getMetric(t *testing.T, gatherer prometheus.Gatherer, metricFamilyName string) *dto.Metric {
+	t.Helper()
+
+	mfs, err := gatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() == metricFamilyName {
+			return mf.GetMetric()[0]
+		}
+	}
+	return nil
+}
+
+func requireMetricHasLabel(t *testing.T, metric *dto.Metric, name, value string) {
+	t.Helper()
+
+	for _, l := range metric.GetLabel() {
+		if l.GetName() == name && l.GetValue() == value {
+			return
+		}
+	}
+	require.FailNowf(t, "metric has no label with name %s and value %s", name, value)
+}

--- a/internal/prometheus/prometheus_test.go
+++ b/internal/prometheus/prometheus_test.go
@@ -132,7 +132,7 @@ func TestHTTPHandler(t *testing.T) {
 	)
 
 	HTTPHandler().ServeHTTP(rec, req)
-	
+
 	require.Equal(t, http.StatusOK, rec.Code)
 	res, err := io.ReadAll(rec.Body)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds the following custom metrics:

`nats_messages_published_total` (Total number of published messages)
`nats_messages_failed_total` (Total number of failed messages)
`nats_message_duration_seconds` (Duration of message publishing in seconds)

Following the same pattern above, it also refactors MongoDB's metrics by merging the following:

`mongodb_succeeded_command_duration_seconds` (Duration of succeeded commands in seconds)
`mongodb_failed_command_duration_seconds` (Duration of failed commands in seconds)
Into

`mongodb_command_duration_seconds` *Duration of commands in seconds(