### PR TITLE
Add 7.0-jammy MongoDB version to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
   build:
     strategy:
       matrix:
-        mongo-version: [5.0-focal, 6.0-focal]
+        mongo-version: [5.0-focal, 6.0-jammy, 7.0-jammy]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MONGO_VERSION ?= 6.0-focal
+MONGO_VERSION ?= 6.0-jammy
 
 .PHONY: test
 


### PR DESCRIPTION
This PR adds `7.0-jammy` MongoDB version to the Github Actions matrix.

It also sets the default MongoDB version when running local tests to `6.0-jammy`.