### PR TITLE
Add observability for the connector's event processing

### DIFF
--- a/internal/mongo/client.go
+++ b/internal/mongo/client.go
@@ -221,7 +221,10 @@ func (c *DefaultClient) WatchCollection(ctx context.Context, opts *WatchCollecti
 			if err != nil {
 				return fmt.Errorf("could not marshal mongo change event from bson: %v", err)
 			}
-			c.logger.Debug("received change event", "changeEvent", string(json))
+
+			if c.logger.Enabled(ctx, slog.LevelDebug) {
+				c.logger.Debug("received change event", "changeEvent", string(json))
+			}
 
 			if _, ok := publishableOperationTypes[operationType]; !ok {
 				if operationType == invalidateOperationType {

--- a/internal/mongo/client.go
+++ b/internal/mongo/client.go
@@ -72,9 +72,10 @@ type DefaultClient struct {
 	name   string
 	logger *slog.Logger
 
-	onCmdStartedEvent   func(dbName, cmdName string)
-	onCmdSucceededEvent func(dbName, cmdName string, duration time.Duration)
-	onCmdFailedEvent    func(dbName, cmdName string, duration time.Duration)
+	onChangeEventProcessing func(collName, subj string, duration time.Duration)
+	onCmdStartedEvent       func(dbName, cmdName string)
+	onCmdSucceededEvent     func(dbName, cmdName string, duration time.Duration)
+	onCmdFailedEvent        func(dbName, cmdName string, duration time.Duration)
 
 	client *mongo.Client
 }
@@ -214,6 +215,7 @@ func (c *DefaultClient) WatchCollection(ctx context.Context, opts *WatchCollecti
 		c.logger.Info("watching mongodb collection", "collName", watchedColl.Name())
 
 		for cs.Next(ctx) {
+			start := time.Now()
 			currentResumeToken := cs.Current.Lookup("_id", "_data").StringValue()
 			operationType := cs.Current.Lookup("operationType").StringValue()
 
@@ -250,6 +252,8 @@ func (c *DefaultClient) WatchCollection(ctx context.Context, opts *WatchCollecti
 				c.logger.Error("could not insert resume token", "err", err)
 				break
 			}
+
+			c.onChangeEventProcessing(watchedColl.Name(), subj, time.Since(start))
 		}
 
 		c.logger.Info("stopped watching mongodb collection", "collName", watchedColl.Name())
@@ -292,6 +296,14 @@ func WithEventListeners(listeners ...EventListener) ClientOption {
 }
 
 type EventListener func(*DefaultClient)
+
+func OnChangeEventProcessingEvent(onChangeEventProcessing func(collName, subj string, duration time.Duration)) EventListener {
+	return func(c *DefaultClient) {
+		if onChangeEventProcessing != nil {
+			c.onChangeEventProcessing = onChangeEventProcessing
+		}
+	}
+}
 
 func OnCmdStartedEvent(onCmdStartedEvent func(dbName, cmdName string)) EventListener {
 	return func(c *DefaultClient) {

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -9,6 +9,27 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+type ConnectorRegisterer struct {
+	changeEventProcessingDuration *prometheus.HistogramVec
+}
+
+func NewConnectorRegisterer(registerer prometheus.Registerer) *ConnectorRegisterer {
+	return &ConnectorRegisterer{
+		changeEventProcessingDuration: promauto.With(registerer).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "connector_change_event_processing_duration_seconds",
+				Help:    "Duration of change event processing in seconds.",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"collection", "subject"},
+		),
+	}
+}
+
+func (r *ConnectorRegisterer) ObserveChangeEventProcessing(collName, subj string, duration time.Duration) {
+	r.changeEventProcessingDuration.WithLabelValues(collName, subj).Observe(duration.Seconds())
+}
+
 type MongoRegisterer struct {
 	mongoCommandsStarted   *prometheus.CounterVec
 	mongoCommandsSucceeded *prometheus.CounterVec

--- a/internal/prometheus/prometheus_test.go
+++ b/internal/prometheus/prometheus_test.go
@@ -12,6 +12,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestConnectorRegisterer_ObserveChangeEventProcessing(t *testing.T) {
+	var (
+		registerer       = prometheus.NewPedanticRegistry()
+		expectedCollName = "coll1"
+		expectedSubj     = "COLL1.insert"
+		expectedDuration = 1 * time.Second
+	)
+
+	cr := NewConnectorRegisterer(registerer)
+	cr.ObserveChangeEventProcessing(expectedCollName, expectedSubj, expectedDuration)
+
+	duration := getMetric(t, registerer, "connector_change_event_processing_duration_seconds")
+	require.NotNil(t, duration)
+	require.Equal(t, expectedDuration.Seconds(), duration.Histogram.GetSampleSum())
+	requireMetricHasLabel(t, duration, "collection", expectedCollName)
+	requireMetricHasLabel(t, duration, "subject", expectedSubj)
+}
+
 func TestMongoRegisterer_IncMongoCmdStarted(t *testing.T) {
 	var (
 		registerer     = prometheus.NewPedanticRegistry()

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -65,11 +65,13 @@ func New(opts ...Option) (*Connector, error) {
 	registerer := prometheus.DefaultRegisterer()
 
 	if c.options.mongoClient == nil {
+		connectorRegisterer := prometheus.NewConnectorRegisterer(registerer)
 		mongoRegisterer := prometheus.NewMongoRegisterer(registerer)
 		mongoClient, err := mongo.NewDefaultClient(
 			mongo.WithMongoUri(c.options.mongoUri),
 			mongo.WithLogger(c.logger),
 			mongo.WithEventListeners(
+				mongo.OnChangeEventProcessingEvent(connectorRegisterer.ObserveChangeEventProcessing),
 				mongo.OnCmdStartedEvent(mongoRegisterer.IncMongoCmdStarted),
 				mongo.OnCmdSucceededEvent(mongoRegisterer.ObserveMongoCmdSucceeded),
 				mongo.OnCmdFailedEvent(mongoRegisterer.ObserveMongoCmdFailed),


### PR DESCRIPTION
This PR adds the following metric:

`connector_change_event_processing_duration_seconds` (Duration of change event processing in seconds)

It also optimizes the event processing by avoiding creating a string from the JSON bytes of the change event unless the logger level is DEBUG.