### PR TITLE
Upgrade to go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22-alpine AS build
+FROM golang:1.23-alpine AS build
 WORKDIR /go/src/github.com/damianiandrea/mongodb-nats-connector
 COPY go.* ./
 RUN go mod download

--- a/Dockerfile.it
+++ b/Dockerfile.it
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 WORKDIR /test
 COPY go.* ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/damianiandrea/mongodb-nats-connector
 
-go 1.22
+go 1.23
 
 require (
 	github.com/docker/docker v27.5.0+incompatible


### PR DESCRIPTION
This PR upgrades the Go version to `1.23`.