### PR TITLE
Upgrade to go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23-alpine AS build
+FROM golang:1.24-alpine AS build
 WORKDIR /go/src/github.com/damianiandrea/mongodb-nats-connector
 COPY go.* ./
 RUN go mod download

--- a/Dockerfile.it
+++ b/Dockerfile.it
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 WORKDIR /test
 COPY go.* ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/damianiandrea/mongodb-nats-connector
 
-go 1.23
+go 1.24
 
 require (
 	github.com/docker/docker v28.0.1+incompatible


### PR DESCRIPTION
This PR upgrades the Go version to `1.24`.